### PR TITLE
fix: Add title and grade fields to paste dialog

### DIFF
--- a/src/pages/Uploads.tsx
+++ b/src/pages/Uploads.tsx
@@ -248,6 +248,28 @@ const Uploads = () => {
                   Paste your content from Word here. We'll do our best to format it correctly.
                 </DialogDescription>
               </DialogHeader>
+              <div>
+                <Label>Title</Label>
+                <Input
+                  value={uploadForm.title}
+                  onChange={(e) => setUploadForm({ ...uploadForm, title: e.target.value })}
+                  placeholder="Enter title"
+                />
+              </div>
+              <div>
+                <Label>Grade</Label>
+                <Select value={uploadForm.grade} onValueChange={(value) => setUploadForm({ ...uploadForm, grade: value })}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select grade" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="Grade 9">Grade 9</SelectItem>
+                    <SelectItem value="Grade 10">Grade 10</SelectItem>
+                    <SelectItem value="Grade 11">Grade 11</SelectItem>
+                    <SelectItem value="Grade 12">Grade 12</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
               <textarea
                 className="w-full h-64 p-2 border rounded-md"
                 value={pastedContent}


### PR DESCRIPTION
This commit fixes a bug where the paste dialog was missing fields for title and grade, causing an error when you submitted pasted content. The dialog now includes these fields, and the submit handler correctly uses them.